### PR TITLE
core: exposing deleteFiles fn

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -283,12 +283,14 @@ packageJson()
 ### File system helpers
 
 ```js
-const { copyFiles, makeDirs } = require('mrm-core')
+const { copyFiles, deleteFiles, makeDirs } = require('mrm-core')
 copyFiles('source dir', 'file name') // Copy file
 copyFiles('source dir', ['file name 1', 'file name 2']) // Copy files
 copyFiles('source dir', 'file name', { overwrite: false }) // Do not overwrite
 makeDirs('dir name') // Create folder
 makeDirs(['dir name 1', 'dir name 2']) // Create folders
+deleteFiles(['pattern', 'glob/**/*']) // Delete patterns
+deleteFiles(['pattern', 'glob/**/*'], { dryRun: true }) // Options from sindresorhus/del
 ```
 
 ### Install and uninstall npm packages

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-code-frame": "^6.22.0",
     "chalk": "^1.1.3",
     "cp-file": "^4.2.0",
+    "del": "^3.0.0",
     "js-yaml": "^3.8.4",
     "listify": "^1.0.0",
     "lodash": "^4.17.4",

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -13,6 +13,8 @@ const copyFiles = fs.copyFiles;
 const makeDirs = fs.makeDirs;
 const deleteFiles = fs.deleteFiles;
 
+del.sync = jest.fn(_ => _);
+
 afterEach(() => {
 	cpFile.sync.mockClear();
 	mkdirp.sync.mockClear();
@@ -51,16 +53,14 @@ it('makeDirs() should create multiple folders', () => {
 	expect(mkdirp.sync).toBeCalledWith('b');
 });
 
-it('deleteFiles() should delete multiple folders', () => {
+it('deleteFiles() should delete multiple files', () => {
 	deleteFiles(['Readme.md', 'License.md']);
-	expect(del.sync).toHaveBeenCalledTimes(2);
-	expect(del.sync).toBeCalledWith(path.resolve('Readme.md'), {});
-	expect(del.sync).toBeCalledWith(path.resolve('License.md'), {});
+	expect(del.sync).toHaveBeenCalledTimes(1);
+	expect(del.sync).toBeCalledWith(['Readme.md', 'License.md'], {});
 });
 
 it('deleteFiles() should pass options to del.sync', () => {
 	deleteFiles(['Readme.md', 'License.md'], { dryRun: true });
-	expect(del.sync).toHaveBeenCalledTimes(2);
-	expect(del.sync).toBeCalledWith(path.resolve('Readme.md'), { dryRun: true });
-	expect(del.sync).toBeCalledWith(path.resolve('License.md'), { dryRun: true });
+	expect(del.sync).toHaveBeenCalledTimes(1);
+	expect(del.sync).toBeCalledWith(['Readme.md', 'License.md'], { dryRun: true });
 });

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -2,17 +2,21 @@
 
 jest.mock('cp-file');
 jest.mock('mkdirp');
+jest.mock('del');
 
 const path = require('path');
 const cpFile = require('cp-file');
 const mkdirp = require('mkdirp');
+const del = require('del');
 const fs = require('../fs');
 const copyFiles = fs.copyFiles;
 const makeDirs = fs.makeDirs;
+const deleteFiles = fs.deleteFiles;
 
 afterEach(() => {
 	cpFile.sync.mockClear();
 	mkdirp.sync.mockClear();
+	del.sync.mockClear();
 });
 
 it('copyFiles() should copy a file', () => {
@@ -45,4 +49,18 @@ it('makeDirs() should create multiple folders', () => {
 	expect(mkdirp.sync).toHaveBeenCalledTimes(2);
 	expect(mkdirp.sync).toBeCalledWith('a');
 	expect(mkdirp.sync).toBeCalledWith('b');
+});
+
+it('deleteFiles() should delete multiple folders', () => {
+	deleteFiles(['Readme.md', 'License.md']);
+	expect(del.sync).toHaveBeenCalledTimes(2);
+	expect(del.sync).toBeCalledWith(path.resolve('Readme.md'), {});
+	expect(del.sync).toBeCalledWith(path.resolve('License.md'), {});
+});
+
+it('deleteFiles() should pass options to del.sync', () => {
+	deleteFiles(['Readme.md', 'License.md'], { dryRun: true });
+	expect(del.sync).toHaveBeenCalledTimes(2);
+	expect(del.sync).toBeCalledWith(path.resolve('Readme.md'), { dryRun: true });
+	expect(del.sync).toBeCalledWith(path.resolve('License.md'), { dryRun: true });
 });

--- a/src/fs.js
+++ b/src/fs.js
@@ -5,13 +5,19 @@ const path = require('path');
 const castArray = require('lodash/castArray');
 const cpFile = require('cp-file');
 const mkdirp = require('mkdirp');
+const del = require('del');
 const chalk = require('chalk');
 const core = require('./core');
 
 /**
+ * @param {path: string} boolean
+ */
+const exists = path => fs.existsSync(path);
+
+/**
  * @param {string} file
  */
-const read = file => (fs.existsSync(file) ? core.readFile(file).trim() : '');
+const read = file => (exists(file) ? core.readFile(file).trim() : '');
 
 /** Copy files from a given directory to the current working directory */
 function copyFiles(sourceDir, files, options) {
@@ -45,7 +51,23 @@ function makeDirs(dirs) {
 	});
 }
 
+/** Delete files from a given path */
+function deleteFiles(dirs, options = {}) {
+	dirs = castArray(dirs);
+
+	dirs.forEach(dir => {
+		const hasFile = exists(path.resolve(dir));
+
+		if (hasFile) {
+			del.sync(path.resolve(dir), options);
+			// eslint-disable-next-line no-console
+			console.log(chalk.green(`Successfully deleted: ${dir}`));
+		}
+	});
+}
+
 module.exports = {
 	copyFiles,
+	deleteFiles,
 	makeDirs,
 };

--- a/src/fs.js
+++ b/src/fs.js
@@ -52,18 +52,11 @@ function makeDirs(dirs) {
 }
 
 /** Delete files from a given path */
-function deleteFiles(dirs, options = {}) {
-	dirs = castArray(dirs);
-
-	dirs.forEach(dir => {
-		const hasFile = exists(path.resolve(dir));
-
-		if (hasFile) {
-			del.sync(path.resolve(dir), options);
-			// eslint-disable-next-line no-console
-			console.log(chalk.green(`Successfully deleted: ${dir}`));
-		}
-	});
+function deleteFiles(patterns, options) {
+	patterns = castArray(patterns);
+	const deletedFiles = del.sync(patterns, options || {});
+	// eslint-disable-next-line no-console
+	console.log(chalk.green(`Deleted: ${deletedFiles}`));
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ module.exports = {
 	updateFile: core.updateFile,
 	applyTemplate: core.applyTemplate,
 	copyFiles: fs.copyFiles,
+	deleteFiles: fs.deleteFiles,
 	makeDirs: fs.makeDirs,
 	install: npm.install,
 	uninstall: npm.uninstall,


### PR DESCRIPTION
Based on the tweet: https://twitter.com/iamsapegin/status/901013203009904640

An idea to fix #3 **Add `delete` for file API**,

- I did not used `delete` because, when importing: `const { delete }` or `import { delete }`, we've a parse error about  the reserved word `delete`:

```
error  Parsing error: Unexpected token delete
```

Following `copyFiles` naming, I used `deleteFiles`

cc @sapegin @okonet