### PR TITLE
Fix issue that copyFIles is unable to overwrite calling script itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-config-tamia": "^4.2.3",
     "eslint-plugin-prettier": "^2.3.1",
     "jest": "^21.2.1",
-    "memfs": "^2.6.0",
+    "memfs": "2.6.0",
     "prettier": "1.8.2"
   },
   "keywords": [

--- a/src/__tests__/__snapshots__/fs.spec.js.snap
+++ b/src/__tests__/__snapshots__/fs.spec.js.snap
@@ -16,6 +16,15 @@ Object {
 }
 `;
 
+exports[`copyFiles() should not try to copy a file if contents is the same 1`] = `
+Object {
+  "/a": "pizza",
+  "/b": "pizza",
+  "/tmpl/a": "pizza",
+  "/tmpl/b": "pizza",
+}
+`;
+
 exports[`deleteFiles() should delete a file 1`] = `
 Object {
   "/b": "coffee",

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -108,9 +108,9 @@ describe('copyFiles()', () => {
 		expect(vol.toJSON()).toEqual(json);
 	});
 
-	it('should throw if contents is the same and errorOnExist=true', () => {
+	it('should throw if file exists and errorOnExist=true', () => {
 		fs.writeFileSync = jest.fn();
-		vol.fromJSON({ '/tmpl/a': 'pizza', '/a': 'pizza' });
+		vol.fromJSON({ '/tmpl/a': 'pizza', '/a': 'coffee' });
 		const fn = () => copyFiles('/tmpl', 'a', { overwrite: false, errorOnExist: true });
 
 		expect(fn).toThrowError('target file already exists');

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -46,22 +46,21 @@ describe('readFile()', () => {
 
 describe('updateFile()', () => {
 	it('should update a file', () => {
-		const contents = 'test';
-		vol.fromJSON({ '/a': contents });
+		vol.fromJSON({ '/a': 'test' });
 
-		updateFile('/a', 'pizza', contents, true);
+		updateFile('/a', 'pizza', true);
 
 		expect(vol.toJSON()).toMatchSnapshot();
 	});
 
 	it('should create a file', () => {
-		updateFile('/a', 'pizza', 'test');
+		updateFile('/a', 'pizza', false);
 
 		expect(vol.toJSON()).toMatchSnapshot();
 	});
 
 	it('should create a folder', () => {
-		updateFile('/a/b', 'pizza', 'test');
+		updateFile('/a/b', 'pizza', false);
 
 		expect(vol.toJSON()).toMatchSnapshot();
 	});
@@ -89,14 +88,14 @@ describe('copyFiles()', () => {
 	});
 
 	it('should not try to copy a file if contents is the same', () => {
-		fs.writeFileSync = jest.fn();
-
+		const spy = jest.spyOn(fs, 'writeFileSync');
 		vol.fromJSON({ '/tmpl/a': 'pizza', '/tmpl/b': 'pizza', '/a': 'pizza', '/b': 'coffee' });
 
 		copyFiles('/tmpl', ['a', 'b']);
 
-		expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-		expect(fs.writeFileSync).toBeCalledWith('b', 'pizza');
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toBeCalledWith('b', 'pizza');
+		expect(vol.toJSON()).toMatchSnapshot();
 	});
 
 	it('should not overwrite a file if overwrite=false', () => {
@@ -109,12 +108,13 @@ describe('copyFiles()', () => {
 	});
 
 	it('should throw if file exists and errorOnExist=true', () => {
-		fs.writeFileSync = jest.fn();
-		vol.fromJSON({ '/tmpl/a': 'pizza', '/a': 'coffee' });
+		const json = { '/tmpl/a': 'pizza', '/a': 'pizza' };
+		vol.fromJSON(json);
+
 		const fn = () => copyFiles('/tmpl', 'a', { overwrite: false, errorOnExist: true });
 
 		expect(fn).toThrowError('target file already exists');
-		expect(fs.writeFileSync).not.toHaveBeenCalled();
+		expect(vol.toJSON()).toEqual(json);
 	});
 
 	it('should throw when source file not found', () => {

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -89,14 +89,14 @@ describe('copyFiles()', () => {
 	});
 
 	it('should not try to copy a file if contents is the same', () => {
-		fs.copySync = jest.fn();
+		fs.writeFileSync = jest.fn();
 
 		vol.fromJSON({ '/tmpl/a': 'pizza', '/tmpl/b': 'pizza', '/a': 'pizza', '/b': 'coffee' });
 
 		copyFiles('/tmpl', ['a', 'b']);
 
-		expect(fs.copySync).toHaveBeenCalledTimes(1);
-		expect(fs.copySync).toBeCalledWith('/tmpl/b', 'b', {});
+		expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+		expect(fs.writeFileSync).toBeCalledWith('b', 'pizza');
 	});
 
 	it('should not overwrite a file if overwrite=false', () => {
@@ -119,7 +119,7 @@ describe('copyFiles()', () => {
 
 		copyFiles('/tmpl', 'a');
 
-		expect(log.added).toBeCalledWith('Copy a');
+		expect(log.added).toBeCalledWith('Create a');
 	});
 
 	it('should not print a file name if contents is the same', () => {

--- a/src/__tests__/fs.spec.js
+++ b/src/__tests__/fs.spec.js
@@ -108,6 +108,15 @@ describe('copyFiles()', () => {
 		expect(vol.toJSON()).toEqual(json);
 	});
 
+	it('should throw if contents is the same and errorOnExist=true', () => {
+		fs.writeFileSync = jest.fn();
+		vol.fromJSON({ '/tmpl/a': 'pizza', '/a': 'pizza' });
+		const fn = () => copyFiles('/tmpl', 'a', { overwrite: false, errorOnExist: true });
+
+		expect(fn).toThrowError('target file already exists');
+		expect(fs.writeFileSync).not.toHaveBeenCalled();
+	});
+
 	it('should throw when source file not found', () => {
 		const fn = () => copyFiles('tmpl', 'a');
 

--- a/src/fs.js
+++ b/src/fs.js
@@ -24,19 +24,28 @@ function updateFile(filename, content, exists) {
 
 /** Copy files from a given directory to the current working directory */
 function copyFiles(sourceDir, files, options) {
+	options = options || { overwrite: true };
 	_.castArray(files).forEach(file => {
 		const sourcePath = path.resolve(sourceDir, file);
 		if (!fs.existsSync(sourcePath)) {
 			throw new MrmError(`copyFiles: source file not found: ${sourcePath}`);
 		}
 
+		const targetExist = fs.existsSync(file);
+		if (targetExist && !options.overwrite) {
+			if (options.errorOnExist) {
+				throw new MrmError(`copyFiles: target file already exists: ${file}`);
+			}
+		}
+
+		const content = read(sourcePath);
+
 		// Skip copy if file contents are the same
-		if (read(sourcePath) === read(file)) {
+		if (content === read(file)) {
 			return;
 		}
 
-		log.added(`Copy ${file}`);
-		fs.copySync(sourcePath, file, options || {});
+		updateFile(file, content, targetExist);
 	});
 }
 

--- a/src/fs.js
+++ b/src/fs.js
@@ -37,6 +37,7 @@ function copyFiles(sourceDir, files, options = {}) {
 			if (errorOnExist) {
 				throw new MrmError(`copyFiles: target file already exists: ${file}`);
 			}
+			return;
 		}
 
 		const content = read(sourcePath);

--- a/src/fs.js
+++ b/src/fs.js
@@ -23,8 +23,9 @@ function updateFile(filename, content, exists) {
 }
 
 /** Copy files from a given directory to the current working directory */
-function copyFiles(sourceDir, files, options) {
-	options = options || { overwrite: true };
+function copyFiles(sourceDir, files, options = {}) {
+	const { overwrite = true, errorOnExist } = options;
+
 	_.castArray(files).forEach(file => {
 		const sourcePath = path.resolve(sourceDir, file);
 		if (!fs.existsSync(sourcePath)) {
@@ -32,8 +33,8 @@ function copyFiles(sourceDir, files, options) {
 		}
 
 		const targetExist = fs.existsSync(file);
-		if (targetExist && !options.overwrite) {
-			if (options.errorOnExist) {
+		if (targetExist && !overwrite) {
+			if (errorOnExist) {
 				throw new MrmError(`copyFiles: target file already exists: ${file}`);
 			}
 		}


### PR DESCRIPTION
### Problem it solves:

My project has a script file to call `mrm`.The script itself is managed by my customized preset. In a new preset version the script needs to be updated, but below error raised:

```
Copy scripts/update.sh

/project/node_modules/mrm/bin/mrm.js:37
                throw err;
                ^

Error: ETXTBSY: text file is busy, unlink '/project/scripts/update.sh'
    at Object.fs.unlinkSync (fs.js:1061:18)
```

It's because `copySync` function try to delete the target file before copy a new one, but the file is in use.

### What was changed in this MR:

Change `copySync` by `updateFile`, which overwrites content if file already exists.

### Impact:

`copySync` accepts some [options](https://github.com/jprichardson/node-fs-extra/blob/master/docs/copy-sync.md). After this change, only `overwrite` and `errorOnExist` are supported.