### PR TITLE
Feature/install check packagejson dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,6 @@
     "sourceType": "script"
   },
   "rules": {
-    "valid-jsdoc": 0,
-    "no-console": 0
+    "valid-jsdoc": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "sourceType": "script"
   },
   "rules": {
-    "valid-jsdoc": 0
+    "valid-jsdoc": 0,
+    "no-console": 0
   }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -339,7 +339,7 @@ install({ lodash: '^4.17.3' }) // Install particular version
 install(['lodash'], { versions: { lodash: '^4.17.3', other: '1.0.0' } }) // Install particular version
 ```
 
-**Note:** These should be valid semver ranges. Works with all semver ranges, like 1.2.3, ^1.2.0 or >=2 (https://semver.org/).
+**Note:** Works with all [semver](https://semver.org/) ranges, like `1.2.3`, `^1.2.0` or `>=2`.
 
 Uninstalls npm package(s) and removes them from `package.json`:
 

--- a/Readme.md
+++ b/Readme.md
@@ -339,7 +339,7 @@ install({ lodash: '^4.17.3' }) // Install particular version
 install(['lodash'], { versions: { lodash: '^4.17.3', other: '1.0.0' } }) // Install particular version
 ```
 
-**Note:** These should be valid semver ranges.
+**Note:** These should be valid semver ranges. Works with all semver ranges, like 1.2.3, ^1.2.0 or >=2 (https://semver.org/).
 
 Uninstalls npm package(s) and removes them from `package.json`:
 

--- a/Readme.md
+++ b/Readme.md
@@ -329,17 +329,17 @@ makeDirs(['dir name 1', 'dir name 2']) // Create folders
 
 ### Install and uninstall npm or Yarn packages
 
-Installs npm package(s) and saves them to `package.json` if they aren’t installed yet or older than required.
+Installs npm package(s) and saves them to `package.json` if they aren’t installed yet or not satisfying range.
 
 ```js
 const { install } = require('mrm-core')
 install('eslint') // Install to devDependencies
 install(['tamia', 'lodash'], { dev: false }) // Install to dependencies
-install({ lodash: '4.17.3' }) // Install particular version
-install(['lodash'], { versions: { lodash: '4.17.3', other: '1.0.0' } }) // Install particular version
+install({ lodash: '^4.17.3' }) // Install particular version
+install(['lodash'], { versions: { lodash: '^4.17.3', other: '1.0.0' } }) // Install particular version
 ```
 
-**Note:** These versions are minimum required versions, Mrm will install the latest version if the current version is lower than required.
+**Note:** These should be valid semver ranges.
 
 Uninstalls npm package(s) and removes them from `package.json`:
 

--- a/src/__tests__/npm.spec.js
+++ b/src/__tests__/npm.spec.js
@@ -148,11 +148,18 @@ describe('install()', () => {
 		);
 	});
 
-	it('should throw when version is invalid', () => {
+	it('should throw when version is invalid version', () => {
 		const spawn = jest.fn();
 		createNodeModulesPackageJson('eslint', '4.2.0');
 		const fn = () => install({ eslint: 'pizza' }, undefined, spawn);
 		expect(fn).toThrow('Invalid npm version');
+	});
+
+	it('should not throw when version is valid range', () => {
+		const spawn = jest.fn();
+		createNodeModulesPackageJson('eslint', '4.2.0');
+		const fn = () => install({ eslint: '~4.2.0' }, undefined, spawn);
+		expect(fn).not.toThrow('Invalid npm version');
 	});
 
 	it('should not throw when package.json not found', () => {

--- a/src/__tests__/npm.spec.js
+++ b/src/__tests__/npm.spec.js
@@ -168,7 +168,7 @@ describe('install()', () => {
 		);
 	});
 
-	it.only('should throw when version is invalid version', () => {
+	it('should throw when version is invalid version', () => {
 		const spawn = jest.fn();
 		createNodeModulesPackageJson('eslint', '4.2.0');
 		const fn = () => install({ eslint: 'pizza' }, undefined, spawn);

--- a/src/__tests__/npm.spec.js
+++ b/src/__tests__/npm.spec.js
@@ -112,9 +112,23 @@ describe('install()', () => {
 		const spawn = jest.fn();
 		createNodeModulesPackageJson('eslint', '4.2.0');
 		createNodeModulesPackageJson('babel-core', '7.1.0');
-		createPackageJson({}, {});
+		createPackageJson({}, {
+			eslint: "*",
+			"babel-core": "*"
+		});
 		install(modules, undefined, spawn);
 		expect(spawn).toHaveBeenCalledTimes(0);
+	});
+
+	it('should install packages that are in node_modules but not in package.json', () => {
+		const spawn = jest.fn();
+		createNodeModulesPackageJson('eslint', '4.2.0');
+		createNodeModulesPackageJson('babel-core', '7.1.0');
+		createPackageJson({}, {
+			eslint: "*"
+		});
+		install(modules, undefined, spawn);
+		expect(spawn).toBeCalledWith('npm', ['install', '--save-dev', 'babel-core@latest'], options);
 	});
 
 	it('should update packages if newer versions are required', () => {
@@ -125,7 +139,10 @@ describe('install()', () => {
 		const spawn = jest.fn();
 		createNodeModulesPackageJson('eslint', '4.2.0');
 		createNodeModulesPackageJson('babel-core', '7.1.0');
-		createPackageJson({}, {});
+		createPackageJson({}, {
+			"eslint": "*",
+			"babel-core": "*"
+		});
 		install(modules, { versions }, spawn);
 		expect(spawn).toBeCalledWith('npm', ['install', '--save-dev', 'eslint@^5.0.0'], options);
 	});
@@ -139,7 +156,10 @@ describe('install()', () => {
 		const spawn = jest.fn();
 		createNodeModulesPackageJson('eslint', '4.2.0');
 		createNodeModulesPackageJson('babel-core', '7.1.0');
-		createPackageJson({}, {});
+		createPackageJson({}, {
+			"eslint": "*",
+			"babel-core": "*"
+		});
 		install(versions, undefined, spawn);
 		expect(spawn).toBeCalledWith(
 			'npm',
@@ -148,7 +168,7 @@ describe('install()', () => {
 		);
 	});
 
-	it('should throw when version is invalid version', () => {
+	it.only('should throw when version is invalid version', () => {
 		const spawn = jest.fn();
 		createNodeModulesPackageJson('eslint', '4.2.0');
 		const fn = () => install({ eslint: 'pizza' }, undefined, spawn);
@@ -183,7 +203,9 @@ describe('install()', () => {
 
 	it('should print only module names that are not installed', () => {
 		createNodeModulesPackageJson('eslint', '4.2.0');
-		createPackageJson({}, {});
+		createPackageJson({}, {
+			"eslint": "*"
+		});
 		install(modules, undefined, () => {});
 
 		expect(log.info).toBeCalledWith('Installing babel-core...');

--- a/src/__tests__/npm.spec.js
+++ b/src/__tests__/npm.spec.js
@@ -119,7 +119,7 @@ describe('install()', () => {
 
 	it('should update packages if newer versions are required', () => {
 		const versions = {
-			eslint: '5.0.0',
+			eslint: '^5.0.0',
 			'babel-core': '7.1.0',
 		};
 		const spawn = jest.fn();
@@ -127,14 +127,14 @@ describe('install()', () => {
 		createNodeModulesPackageJson('babel-core', '7.1.0');
 		createPackageJson({}, {});
 		install(modules, { versions }, spawn);
-		expect(spawn).toBeCalledWith('npm', ['install', '--save-dev', 'eslint@latest'], options);
+		expect(spawn).toBeCalledWith('npm', ['install', '--save-dev', 'eslint@^5.0.0'], options);
 	});
 
 	it('should accept dependencies list as an object', () => {
 		const versions = {
-			eslint: '5.0.0',
+			eslint: '^5.0.0',
 			'babel-core': '7.1.0',
-			prettier: '1.1.0',
+			prettier: '^1.1.0',
 		};
 		const spawn = jest.fn();
 		createNodeModulesPackageJson('eslint', '4.2.0');
@@ -143,7 +143,7 @@ describe('install()', () => {
 		install(versions, undefined, spawn);
 		expect(spawn).toBeCalledWith(
 			'npm',
-			['install', '--save-dev', 'eslint@latest', 'prettier@latest'],
+			['install', '--save-dev', 'eslint@^5.0.0', 'prettier@^1.1.0'],
 			options
 		);
 	});

--- a/src/npm.js
+++ b/src/npm.js
@@ -31,7 +31,7 @@ function install(deps, options, exec) {
 	}
 
 	log.info(`Installing ${listify(newDeps)}...`);
-	const versionedDeps = newDeps.map(getVersionedDep(versions));
+	const versionedDeps = newDeps.map(dep => getVersionedDep(dep, versions));
 	run(versionedDeps, { dev }, exec);
 }
 
@@ -105,15 +105,12 @@ function runYarn(deps, options, exec) {
 
 /**
  * Add version or latest to package name
- * @param {string[]} deps
+ * @param {string} dep
  * @param {string[]} versions
  */
-function getVersionedDep(versions) {
-	return ((dep) => {
-		const version = versions[dep] ||"latest";
-
-		return `${dep}@${version}`;
-	});
+function getVersionedDep(dep, versions) {
+  const version = versions[dep] || 'latest';
+  return `${dep}@${version}`;
 }
 
 /**

--- a/src/npm.js
+++ b/src/npm.js
@@ -31,8 +31,16 @@ function install(deps, options, exec) {
 	}
 
 	log.info(`Installing ${listify(newDeps)}...`);
-	const versionedDeps = newDeps.map(d => `${d}@latest`);
+	const versionedDeps = getVersionedDeps(newDeps, versions);
 	run(versionedDeps, { dev }, exec);
+}
+
+function getVersionedDeps(deps, versions) {
+	return deps.map((d) => {
+		const version = versions[d] ||"latest";
+
+		return `${d}@${version}`;
+	});
 }
 
 /* Uninstall given npm packages */

--- a/src/npm.js
+++ b/src/npm.js
@@ -31,7 +31,7 @@ function install(deps, options, exec) {
 	}
 
 	log.info(`Installing ${listify(newDeps)}...`);
-	const versionedDeps = getVersionedDeps(newDeps, versions);
+	const versionedDeps = newDeps.map(getVersionedDep(versions));
 	run(versionedDeps, { dev }, exec);
 }
 
@@ -108,11 +108,11 @@ function runYarn(deps, options, exec) {
  * @param {string[]} deps
  * @param {string[]} versions
  */
-function getVersionedDeps(deps, versions) {
-	return deps.map((d) => {
-		const version = versions[d] ||"latest";
+function getVersionedDep(versions) {
+	return ((dep) => {
+		const version = versions[dep] ||"latest";
 
-		return `${d}@${version}`;
+		return `${dep}@${version}`;
 	});
 }
 

--- a/src/npm.js
+++ b/src/npm.js
@@ -35,14 +35,6 @@ function install(deps, options, exec) {
 	run(versionedDeps, { dev }, exec);
 }
 
-function getVersionedDeps(deps, versions) {
-	return deps.map((d) => {
-		const version = versions[d] ||"latest";
-
-		return `${d}@${version}`;
-	});
-}
-
 /* Uninstall given npm packages */
 function uninstall(deps, options, exec) {
 	options = options || {};
@@ -112,6 +104,19 @@ function runYarn(deps, options, exec) {
 	return exec('yarn', args, {
 		stdio: options.stdio === undefined ? 'inherit' : options.stdio,
 		cwd: options.cwd,
+	});
+}
+
+/**
+ * Add version or latest to package name
+ * @param {string[]} deps
+ * @param {string[]} versions
+ */
+function getVersionedDeps(deps, versions) {
+	return deps.map((d) => {
+		const version = versions[d] ||"latest";
+
+		return `${d}@${version}`;
 	});
 }
 

--- a/src/npm.js
+++ b/src/npm.js
@@ -119,7 +119,7 @@ function getInstalledVersion(name) {
 
 /**
  * Return only not installed dependencies, or dependencies which installed
- * version is lower than required.
+ * version doesn't satisfy range.
  *
  * @param {string[]} deps
  * @param {object} [versions]
@@ -141,16 +141,16 @@ function getUnsatisfiedDeps(deps, versions) {
 			return !installed;
 		}
 
-		if (!semver.valid(required)) {
+		if (!semver.validRange(required)) {
 			throw new MrmError(
 				`Invalid npm version: ${
 					required
-				}. Use only version number, no tilda (~), caret (^) or ranges.`
+				}. Use proper semver range syntax.`
 			);
 		}
 
-		// Install if installed version is lower than required
-		return semver.lt(installed, required);
+		// Install if installed version doesn't satisfy range
+		return !semver.satisfies(installed, required);
 	});
 }
 

--- a/src/npm.js
+++ b/src/npm.js
@@ -42,7 +42,7 @@ function uninstall(deps, options, exec) {
 	const dev = options.dev !== false;
 	const run = options.yarn || isUsingYarn() ? runYarn : runNpm;
 
-	const installed = getInstalledDependencies({ dev });
+	const installed = getOwnDependencies({ dev });
 
 	const newDeps = deps.filter(dep => installed[dep]);
 
@@ -121,7 +121,7 @@ function getVersionedDep(versions) {
  * @param {Object} options
  * @param {boolean} [options.dev=true] --dev (production by default)
  */
-function getInstalledDependencies(options) {
+function getOwnDependencies(options) {
 	const pkg = packageJson({
 		dependencies: {},
 		devDependencies: {},
@@ -149,7 +149,7 @@ function getInstalledVersion(name) {
  * @return {string[]}
  */
 function getUnsatisfiedDeps(deps, versions, options) {
-	const installedDependencies = getInstalledDependencies(options);
+	const ownDependencies = getOwnDependencies(options);
 
 	return deps.filter(dep => {
 		const required = versions[dep];
@@ -162,16 +162,16 @@ function getUnsatisfiedDeps(deps, versions, options) {
 			);
 		}
 
-		// Module is not in package.json dependencies
-		if (!installedDependencies[dep]) {
-			return true
-		}
-
 		const installed = getInstalledVersion(dep);
 
 		// Package isn’t installed yet
 		if (!installed) {
 			return true;
+		}
+
+		// Module is installed but not in package.json dependencies
+		if (!ownDependencies[dep]) {
+			return true
 		}
 
 		// No required version specified

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ interface File {
 
 interface Ini {
 	exists() : boolean;
+	get(): any;
 	get(section?: string): any;
 	set(section: string, value: any): this;
 	unset(section: string): this;
@@ -16,6 +17,7 @@ interface Ini {
 
 interface Json {
 	exists() : boolean;
+	get(): any
 	get(address: string | string[], defaultValue?: any): any;
 	set(address: string | string[], value: any): this;
 	unset(address: string | string[]): this;
@@ -48,6 +50,7 @@ interface Template {
 
 interface Yaml {
 	exists() : boolean;
+	get(): any;
 	get(address: string | string[], defaultValue?: any): any;
 	set(address: string | string[], value: any): this;
 	unset(address: string | string[]): this;


### PR DESCRIPTION
Checks for module in package.json before installing and run install if module is not in there.

This is needed to satisfy the "no implicit dependencies" rule (https://palantir.github.io/tslint/rules/no-implicit-dependencies/).

We apply this rule at Collibra so this is a must have for us :)

Shouldn't be a breaking change.